### PR TITLE
Make overlay hitmarkers more precise.

### DIFF
--- a/Assets/vrc-rv32ima/Debug/DataView.shader
+++ b/Assets/vrc-rv32ima/Debug/DataView.shader
@@ -54,14 +54,16 @@
                     pcv % _MainSystemMemory_TexelSize.z,
                     pcv / int( _MainSystemMemory_TexelSize.w )
                 ) - .5;
-				float pcdist = length( dpos );
-                float fw = fwidth(thisCoord);
+                float fw = fwidth( thisCoord );
                 float cross_thickness = 1 + 2*fw;  // make it more crisp as you look closely
-				float cross = max( cross_thickness-abs( dpos.x - dpos.y ), cross_thickness-abs( dpos.x + dpos.y ) );
+				float cross = max(
+                    cross_thickness - abs( dpos.x - dpos.y ),
+                    cross_thickness - abs( dpos.x + dpos.y )
+                );
 
-                float sharpness = .5/fw;  // mathematical antialiasing
+                float sharpness = 1/fw;  // mathematical antialiasing
                 // set a min radius around the pixel and max radius around the cross
-                float circular_mask = saturate( sharpness*(10.0 - abs( 10.70710678118 - pcdist ) ));
+                float circular_mask = saturate( sharpness*(10.0 - abs( 10.70710678118 - length( dpos ) ) ));
 				return min(circular_mask, saturate( sharpness*cross ) );
 			}
 

--- a/Assets/vrc-rv32ima/Debug/DataView.shader
+++ b/Assets/vrc-rv32ima/Debug/DataView.shader
@@ -3,7 +3,7 @@
     Properties
     {
         _MainSystemMemory ("Texture", 2D) = "white" {}
-		[Toggle(_DoOverlay)] _DoOverlay( "Do Overlay", float ) = 1.0
+        [Toggle(_DoOverlay)] _DoOverlay( "Do Overlay", float ) = 1.0
     }
     SubShader
     {
@@ -17,7 +17,7 @@
             #pragma fragment frag
             // make fog work
             #pragma multi_compile_fog
-			#pragma multi_compile _ _DoOverlay
+            #pragma multi_compile _ _DoOverlay
             #include "UnityCG.cginc"
 
             struct appdata
@@ -45,18 +45,18 @@
                 UNITY_TRANSFER_FOG(o, o.vertex);
                 return o;
             }
-			
-			float hitmarker( uint pcreg, float2 thisCoord )
-			{
-				uint pcv = _MainSystemMemory[uint2( pcreg/4, _MainSystemMemory_TexelSize.w - 1 )][pcreg%4] - 0x80000000;
-				pcv /= 16;
-				float2 dpos = thisCoord - float2(
+
+            float hitmarker( uint pcreg, float2 thisCoord )
+            {
+                uint pcv = _MainSystemMemory[uint2( pcreg/4, _MainSystemMemory_TexelSize.w - 1 )][pcreg%4] - 0x80000000;
+                pcv /= 16;
+                float2 dpos = thisCoord - float2(
                     pcv % _MainSystemMemory_TexelSize.z,
                     pcv / int( _MainSystemMemory_TexelSize.w )
                 ) - .5;
                 float fw = fwidth( thisCoord );
                 float cross_thickness = 1 + 2*fw;  // make it more crisp as you look closely
-				float cross = max(
+                float cross = max(
                     cross_thickness - abs( dpos.x - dpos.y ),
                     cross_thickness - abs( dpos.x + dpos.y )
                 );
@@ -64,24 +64,24 @@
                 float sharpness = 1/fw;  // mathematical antialiasing
                 // set a min radius around the pixel and max radius around the cross
                 float circular_mask = saturate( sharpness*(10.0 - abs( 10.70710678118 - length( dpos ) ) ));
-				return min(circular_mask, saturate( sharpness*cross ) );
-			}
+                return min(circular_mask, saturate( sharpness*cross ) );
+            }
 
             float4 frag (v2f i) : SV_Target
             {
                 float4 col = _MainSystemMemory[i.uv*_MainSystemMemory_TexelSize.zw] / (float)(0xffffffff);
-				float2 thisCoord = i.uv * _MainSystemMemory_TexelSize.zw;
+                float2 thisCoord = i.uv * _MainSystemMemory_TexelSize.zw;
 
-				#if _DoOverlay
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 10, thisCoord ) );
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 11, thisCoord ) );
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 12, thisCoord ) );
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 13, thisCoord ) );
+                #if _DoOverlay
+                    col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 10, thisCoord ) );
+                    col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 11, thisCoord ) );
+                    col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 12, thisCoord ) );
+                    col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 13, thisCoord ) );
 
-					col = lerp( col, float4( 1.0, 0.0, 0.0, 0.0 ), hitmarker( 32, thisCoord ) );
-					col = lerp( col, float4( 0.0, 0.0, 1.0, 0.0 ), hitmarker(  2, thisCoord ) );
-					col = lerp( col, float4( 0.0, 1.0, 1.0, 0.0 ), hitmarker(  4, thisCoord ) );
-				#endif
+                    col = lerp( col, float4( 1.0, 0.0, 0.0, 0.0 ), hitmarker( 32, thisCoord ) );
+                    col = lerp( col, float4( 0.0, 0.0, 1.0, 0.0 ), hitmarker(  2, thisCoord ) );
+                    col = lerp( col, float4( 0.0, 1.0, 1.0, 0.0 ), hitmarker(  4, thisCoord ) );
+                #endif
                 // apply fog
                 UNITY_APPLY_FOG(i.fogCoord, col);
                 return col;

--- a/Assets/vrc-rv32ima/Debug/DataView.shader
+++ b/Assets/vrc-rv32ima/Debug/DataView.shader
@@ -50,8 +50,10 @@
 			{
 				uint pcv = _MainSystemMemory[uint2( pcreg/4, _MainSystemMemory_TexelSize.w - 1 )][pcreg%4] - 0x80000000;
 				pcv /= 16;
-				thisCoord += 0.25;
-				float2 dpos = thisCoord - float2( pcv % _MainSystemMemory_TexelSize.z, pcv / _MainSystemMemory_TexelSize.w );
+				float2 dpos = thisCoord - float2(
+                    pcv % _MainSystemMemory_TexelSize.z,
+                    pcv / int(_MainSystemMemory_TexelSize.w)
+                ) - .5;
 				float pcdist = length( dpos );
 				float xclamp = max( 2.0-abs( dpos.x - dpos.y ), 2.0-abs( dpos.x + dpos.y ) );
 				return min( saturate( 10.0 - abs( 11.0 - pcdist ) ), saturate(xclamp) );
@@ -62,9 +64,8 @@
                 // sample the texture
                 float4 col = _MainSystemMemory[i.uv*_MainSystemMemory_TexelSize.zw] / (float)(0xffffffff);
 				float2 thisCoord = i.uv * _MainSystemMemory_TexelSize.zw;
-				
+
 				#if _DoOverlay
-					#define pcreg 32
 					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 10, thisCoord ) );
 					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 11, thisCoord ) );
 					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 12, thisCoord ) );

--- a/Assets/vrc-rv32ima/Debug/DataView.shader
+++ b/Assets/vrc-rv32ima/Debug/DataView.shader
@@ -46,7 +46,7 @@
                 return o;
             }
 			
-			float recoord( uint pcreg, float2 thisCoord )
+			float hitmarker( uint pcreg, float2 thisCoord )
 			{
 				uint pcv = _MainSystemMemory[uint2( pcreg/4, _MainSystemMemory_TexelSize.w - 1 )][pcreg%4] - 0x80000000;
 				pcv /= 16;
@@ -71,14 +71,14 @@
 				float2 thisCoord = i.uv * _MainSystemMemory_TexelSize.zw;
 
 				#if _DoOverlay
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 10, thisCoord ) );
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 11, thisCoord ) );
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 12, thisCoord ) );
-					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), recoord( 13, thisCoord ) );
+					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 10, thisCoord ) );
+					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 11, thisCoord ) );
+					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 12, thisCoord ) );
+					col = lerp( col, float4( 1.0, 1.0, 0.0, 0.0 ), hitmarker( 13, thisCoord ) );
 
-					col = lerp( col, float4( 1.0, 0.0, 0.0, 0.0 ), recoord( 32, thisCoord ) );
-					col = lerp( col, float4( 0.0, 0.0, 1.0, 0.0 ), recoord(  2, thisCoord ) );
-					col = lerp( col, float4( 0.0, 1.0, 1.0, 0.0 ), recoord(  4, thisCoord ) );
+					col = lerp( col, float4( 1.0, 0.0, 0.0, 0.0 ), hitmarker( 32, thisCoord ) );
+					col = lerp( col, float4( 0.0, 0.0, 1.0, 0.0 ), hitmarker(  2, thisCoord ) );
+					col = lerp( col, float4( 0.0, 1.0, 1.0, 0.0 ), hitmarker(  4, thisCoord ) );
 				#endif
                 // apply fog
                 UNITY_APPLY_FOG(i.fogCoord, col);


### PR DESCRIPTION
# Before:
Markers where improperly vertically centered (horizontal line added for clarity)
![image](https://github.com/cnlohr/vrc-rv32ima/assets/888068/c519673c-3ff3-4cfc-9b6e-a2d5317d0a83)

and they were blurry when viewing the highlighted pixel close up
![image](https://github.com/cnlohr/vrc-rv32ima/assets/888068/b3f7a268-a224-43a8-8acd-add8a77d8790)

# After:
They now look sharp at all distances and are properly centered on the pixel they highlight.
![image](https://github.com/cnlohr/vrc-rv32ima/assets/888068/c2b147f7-2631-45f0-b092-f91b9957aa87)

